### PR TITLE
Update incorrect commands

### DIFF
--- a/input/guides/raspberry-pi-3-baby-monitor.md
+++ b/input/guides/raspberry-pi-3-baby-monitor.md
@@ -266,7 +266,7 @@ You see "card 1" and "device 0" so my microphone ID will be `hw:1,0`.
 
 Now, let's make a script we can run to start Picam. **Replace "hw:1,0" with your device ID above if it's different.**:
 
-    echo -e "sudo bash /home/pi/make_dirs.sh\nsudo /home/pi/picam/picam -o /run/shm/hls --time --alsadev hw:1,0 > /var/log/picam.log 2&>1" > run_picam.sh
+    echo -e "sudo bash /home/pi/make_dirs.sh\nsudo /home/pi/picam/picam -o /run/shm/hls --time --alsadev hw:1,0 > /var/log/picam.log 2>&1" > run_picam.sh
     chmod +x run_picam.sh
 
 This creates a `run_picam.sh` script in our root (`~`) directory and marks it as executable. The script starts Picam with a HLS stream output to the RAM drive (fast) and uses our microphone as the recording device. It also writes out the current timestamp in the bottom corner of the stream. There are a [ton of other options](https://github.com/iizukanao/picam) too including subtitles, etc. The default video resolution is 720p which is fine enough for a babycam.
@@ -297,7 +297,7 @@ For reference, this is my full `run_picam.sh` script for my Pi:
 
 ```bash
 sudo bash /home/pi/make_dirs.sh
-sudo /home/pi/picam/picam -o /run/shm/hls --samplerate 32000 --channels 2 --audiobitrate 96000 --videobitrate 4000000 --vfr --avclevel 3.1 --autoex --time --alsadev hw:1,0  >/var/log/picam.log 2>&1
+sudo /home/pi/picam/picam -o /run/shm/hls --samplerate 32000 --channels 2 --audiobitrate 96000 --videobitrate 4000000 --vfr --avclevel 3.1 --autoex --time --alsadev hw:1,0  > /var/log/picam.log 2>&1
 ```
 
 ## Running Picam at startup
@@ -392,9 +392,9 @@ In the editor, scroll down to right before `location / {` and add a new block ab
 
 This adds a new /hls URL that points to the /run/shm/hls directory Picam is outputting the stream to.
 
-Ensure nginx is started (it will start automatically):
+Restart nginx to allow the changes to take effect:
 
-    sudo /etc/init.d/nginx start
+    sudo /etc/init.d/nginx restart
     
 This starts the web server. Now you can browse (on the Pi or other device) to the root of the site and view the nginx welcome page.
 

--- a/input/guides/raspberry-pi-3-baby-monitor.md
+++ b/input/guides/raspberry-pi-3-baby-monitor.md
@@ -50,6 +50,10 @@ This guide will show you how to build your own DIY baby monitor using a Raspberr
 
 ## Updates
 
+### 2020-08-25
+
+- Command typo fixes by [cowley05](https://github.com/cowley05) ([#27](https://github.com/kamranayub/kamranayub.github.io/pull/27))
+
 ### 2019-11-13
 
 - Add video walkthrough pitch


### PR DESCRIPTION
There were what I suspect are typos in the commands for run_picam.sh and the example script with redirection of standard error and output. 2&>1 should be 2>&1. (and a missing space)

The nginx start command does not work since nginx will already be running after install, a restart is required for the changes to take effect.